### PR TITLE
Improve layout with side-by-side selectors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,35 +59,41 @@ function App() {
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Test Run Selection */}
-        <TestRunSelector
-          selectedRuns={selectedRuns}
-          onSelectionChange={setSelectedRuns}
-        />
+        <div className="lg:flex lg:space-x-6">
+          <div className="lg:w-1/3 lg:max-w-sm space-y-6">
+            {/* Test Run Selection */}
+            <TestRunSelector
+              selectedRuns={selectedRuns}
+              onSelectionChange={setSelectedRuns}
+            />
 
-        {/* Template Selection */}
-        <TemplateSelector
-          selectedTemplate={selectedTemplate}
-          onTemplateSelect={setSelectedTemplate}
-        />
-
-        {/* Chart Display */}
-        {selectedTemplate && (
-          <div className="relative">
-            {loading && (
-              <div className="absolute inset-0 bg-white bg-opacity-75 flex items-center justify-center z-10 rounded-lg">
-                <div className="flex items-center">
-                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mr-3"></div>
-                  <span className="text-gray-600">Loading performance data...</span>
-                </div>
-              </div>
-            )}
-            <InteractiveChart
-              template={selectedTemplate}
-              data={performanceData}
+            {/* Template Selection */}
+            <TemplateSelector
+              selectedTemplate={selectedTemplate}
+              onTemplateSelect={setSelectedTemplate}
             />
           </div>
-        )}
+
+          <div className="mt-6 lg:mt-0 lg:flex-1">
+            {/* Chart Display */}
+            {selectedTemplate && (
+              <div className="relative">
+                {loading && (
+                  <div className="absolute inset-0 bg-white bg-opacity-75 flex items-center justify-center z-10 rounded-lg">
+                    <div className="flex items-center">
+                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mr-3"></div>
+                      <span className="text-gray-600">Loading performance data...</span>
+                    </div>
+                  </div>
+                )}
+                <InteractiveChart
+                  template={selectedTemplate}
+                  data={performanceData}
+                />
+              </div>
+            )}
+          </div>
+        </div>
 
         {/* Instructions */}
         {selectedRuns.length === 0 && (


### PR DESCRIPTION
## Summary
- place the test run and template selectors in a left column
- keep the chart on the right for a clearer layout

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68571ccc71e48323816fc104ca2fa03e